### PR TITLE
Ensure aliases work on merged plots

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Alias.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Alias.java
@@ -65,6 +65,9 @@ public class Alias extends SubCommand {
             return false;
         }
 
+        // Always operate on the base plot to ensure merged plots are handled correctly
+        plot = plot.getBasePlot(false);
+
         if (!plot.hasOwner()) {
             player.sendMessage(TranslatableCaption.of("working.plot_not_claimed"));
             return false;

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -2155,16 +2155,15 @@ public class Plot {
      * @param alias The alias
      */
     public void setAlias(String alias) {
+        if (alias == null) {
+            alias = "";
+        }
         for (Plot current : this.getConnectedPlots()) {
-            String name = this.getSettings().getAlias();
-            if (alias == null) {
-                alias = "";
+            String currentAlias = current.getSettings().getAlias();
+            if (!currentAlias.equals(alias)) {
+                current.getSettings().setAlias(alias);
+                DBFunc.setAlias(current, alias);
             }
-            if (name.equals(alias)) {
-                return;
-            }
-            current.getSettings().setAlias(alias);
-            DBFunc.setAlias(current, alias);
         }
     }
 


### PR DESCRIPTION
## Summary
- Always resolve the base plot before setting or removing an alias so merged plots can be handled from any section
- Update plot alias setting logic to iterate over all connected plots, preventing early returns that skipped some merged plots

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b06612cd748331a69f062b5ca2f30a